### PR TITLE
BE CD 스크립트의 deploy.sh 실행 전 EC2 경로 변경

### DIFF
--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -41,6 +41,7 @@ jobs:
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           port: ${{ secrets.REMOTE_SSH_PORT }}
           script: |
+            cd $GITHUB_WORKSPACE/backend
             ./deploy.sh
 
       - name: Remove Github Actions IP from security group


### PR DESCRIPTION
Github Actions의 EC2에서 deploy.sh를 찾지 못하는 상황 발생